### PR TITLE
Missing initWithWebView selector in CDVPlugin fixes #2

### DIFF
--- a/src/ios/CDVKeychain.m
+++ b/src/ios/CDVKeychain.m
@@ -22,13 +22,9 @@
 
 @implementation CDVKeychain
 
-- (CDVPlugin*) initWithWebView:(UIWebView*)theWebView
+- (void) initPlugin
 {
-    self = (CDVKeychain*)[super initWithWebView:(UIWebView*)theWebView];
-    if (self) {
 		// initialization here
-    }
-    return self;
 }
 
 


### PR DESCRIPTION
Whoa! This should add support for `cordova-ios 4.x.x` platforms
